### PR TITLE
config の t_dirに初期値を追加

### DIFF
--- a/include/cub_config.h
+++ b/include/cub_config.h
@@ -31,6 +31,7 @@ typedef struct s_rgb
 // - EAST,WEST,NORTH,SOUTH: 東西南北の4方向
 typedef enum e_dir
 {
+	DIR_UNSET = -1,
 	EAST = 0,
 	WEST,
 	NORTH,
@@ -39,6 +40,7 @@ typedef enum e_dir
 
 
 // 壁テクスチャIDを表す列挙体
+//
 // 役割:
 // - 四方向の壁テクスチャを配列 index で一元管理する。
 // 主な値:

--- a/sandbox/parse/parse_test/print_spawn.c
+++ b/sandbox/parse/parse_test/print_spawn.c
@@ -4,6 +4,8 @@
 
 static const char	*dir_to_str(t_dir dir)
 {
+	if (dir == DIR_UNSET)
+		return ("DIR_UNSET : It hasn't changed from the initial value.");
 	if (dir == NORTH)
 		return ("NORTH");
 	if (dir == SOUTH)
@@ -12,7 +14,7 @@ static const char	*dir_to_str(t_dir dir)
 		return ("EAST");
 	if (dir == WEST)
 		return ("WEST");
-	return ("UNKNOWN");
+	return ("UNKNOWN : The value is invalid.");
 }
 
 // 概要 : スポーン座標と初期方角を表示する

--- a/src/parse/init_config.c
+++ b/src/parse/init_config.c
@@ -6,7 +6,7 @@
 /*   By: iokuno <iokuno@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/03/14 16:45:16 by iokuno            #+#    #+#             */
-/*   Updated: 2026/03/14 18:39:41 by iokuno           ###   ########.fr       */
+/*   Updated: 2026/03/14 21:34:53 by iokuno           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,7 @@ void	init_config(t_config *config)
 	config->map.height = 0;
 	config->spawn.row = -1;
 	config->spawn.col = -1;
-	config->spawn.dir = NORTH;
+	config->spawn.dir = DIR_UNSET;
 }
 
 // 概要 : t_rgbの初期化


### PR DESCRIPTION
* fix #6

# 概要
`t_config` 初期化時に「未設定にもかかわらず有効値を入れてしまう」状態を避けるため、
方向を表す enum に未設定状態 `DIR_UNSET` を追加しました。

これにより、spawn の方向が未設定かどうかを明確に判定できるようにしました。

# 変更点
- enum `t_dir` に `DIR_UNSET` を追加
- `init_config()` の初期化値を `DIR_UNSET` に変更
- `t_config` の内容を出力する DEBUG 用関数に `DIR_UNSET` 表示処理を追加

# 影響範囲
- `t_config` を標準出力するテスト関数を更新  
  - `DIR_UNSET` を判定・表示できるように変更