### PR TITLE
押下状態をフレーム間で保存できるようにしたよ

### DIFF
--- a/include/game_config.h
+++ b/include/game_config.h
@@ -8,10 +8,6 @@
 #define FOV_HALF_TAN 0.66
 
 // linux,mac対応のゴリ押しkeycode
-#ifndef KEYCODES_H
-# define KEYCODES_H
-
-
 # if defined(__linux__)
 #  define PLATFORM_LINUX 1
 # elif defined(__APPLE__) && defined(__MACH__)
@@ -46,7 +42,5 @@
 #  define KEY_W         13
 
 # endif
-
-#endif
 
 #endif

--- a/include/game_config.h
+++ b/include/game_config.h
@@ -4,8 +4,16 @@
 
 
 #define PLAYER_MOVE_SPEED 3.0
-#define PLAYER_ROT_SPEED 2.0
-#define FOV_HALF_TAN 0.66
+#define PLAYER_ROT_SPEED 2.0 
+#define FOV_HALF_TAN 0.66 
+
+
+#define EVENT_KEY_PRESS      2 
+#define EVENT_KEY_RELEASE    3 
+#define EVENT_DESTROY        17
+#define MASK_KEY_PRESS       (1L << 0)
+#define MASK_KEY_RELEASE     (1L << 1)
+
 
 // linux,mac対応のゴリ押しkeycode
 # if defined(__linux__)

--- a/include/game_config.h
+++ b/include/game_config.h
@@ -3,6 +3,9 @@
 
 
 
+#define PLAYER_MOVE_SPEED 3.0
+#define PLAYER_ROT_SPEED 2.0
+#define FOV_HALF_TAN 0.66
 
 // linux,mac対応のゴリ押しkeycode
 #ifndef KEYCODES_H

--- a/include/game_init.h
+++ b/include/game_init.h
@@ -20,7 +20,13 @@ typedef enum e_game_init_mask
 bool	init_game_mlx(t_game *game_state);
 bool	init_game_wall_textures(t_game *game_state, t_tex_path texture_paths);
 void	init_player(t_player *player, t_spawn spawn);
+void	init_input(t_input *input);
 void	destroy_texture_assets(t_assets *assets, t_mlx mlx_context);
 void	destroy_game_resources(t_game *game_state);
+
+int		handle_key_press(int keycode, t_game *game);
+int		handle_key_release(int keycode, t_game *game);
+int		handle_close(t_game *game);
+void	register_hooks(t_game *game);
 
 #endif

--- a/sandbox/render/render_sandbox_main.c
+++ b/sandbox/render/render_sandbox_main.c
@@ -178,11 +178,29 @@ static bool	init_sandbox_config(t_config *config){
 
 // debug
 void	debug_print_texture_image_all(const t_assets *assets);
-void debug_print_player_pos_all(const t_player player);
+void	debug_print_player_pos_all(const t_player player);
 
 // #include "cub3d.h"
 // #include "game_init.h"
+#include "game_config.h"
 
+static int	sandbox_loop_hook(t_game *game)
+{
+	if (game->input.quit || !game->running)
+	{
+		destroy_game_resources(game);
+		free_sandbox_config(&game->config);
+		exit(0);
+	}
+	if (game->input.move_forward || game->input.move_backward
+		|| game->input.strafe_left || game->input.strafe_right
+		|| game->input.turn_left || game->input.turn_right)
+		printf("fwd=%d bwd=%d sl=%d sr=%d tl=%d tr=%d\n",
+			game->input.move_forward, game->input.move_backward,
+			game->input.strafe_left, game->input.strafe_right,
+			game->input.turn_left, game->input.turn_right);
+	return (0);
+}
 
 int	main(void)
 {
@@ -192,21 +210,25 @@ int	main(void)
 	game = (t_game){0};
 	if (!init_sandbox_config(&game.config))
 		return (1);
-	// src/
 	ok = init_game_mlx(&game);
 	if (ok)
 		ok = init_game_wall_textures(&game, game.config.tex);
 	if (ok)
 		init_player(&game.player, game.config.spawn);
-	// debug/
-	if (ok)
-		debug_print_texture_image_all(&game.assets);
-	if (ok)
-		debug_print_player_pos_all(game.player);
-
-	destroy_game_resources(&game);
-	free_sandbox_config(&game.config);
 	if (!ok)
+	{
+		destroy_game_resources(&game);
+		free_sandbox_config(&game.config);
 		return (1);
+	}
+	// debug/
+	debug_print_texture_image_all(&game.assets);
+	debug_print_player_pos_all(game.player);
+
+	init_input(&game.input);
+	game.running = true;
+	register_hooks(&game);
+	mlx_loop_hook(game.mlx.mlx, sandbox_loop_hook, &game);
+	mlx_loop(game.mlx.mlx);
 	return (0);
 }

--- a/src/game_init/init_player.c
+++ b/src/game_init/init_player.c
@@ -1,5 +1,5 @@
 #include "game_init.h"
-
+#include "game_config.h"
 
 // 何する関数か:
 // - 方角に対応する前方ベクトルを返す。

--- a/src/game_init/init_player.c
+++ b/src/game_init/init_player.c
@@ -1,8 +1,5 @@
 #include "game_init.h"
 
-#define PLAYER_MOVE_SPEED 3.0
-#define PLAYER_ROT_SPEED 2.0
-#define FOV_HALF_TAN 0.66
 
 // 何する関数か:
 // - 方角に対応する前方ベクトルを返す。

--- a/src/handle_input.c
+++ b/src/handle_input.c
@@ -1,0 +1,63 @@
+#include "cub3d.h"
+#include "game_config.h"
+#include "game_init.h"
+
+void	init_input(t_input *input)
+{
+	input->move_forward = false;
+	input->move_backward = false;
+	input->strafe_left = false;
+	input->strafe_right = false;
+	input->turn_left = false;
+	input->turn_right = false;
+	input->quit = false;
+}
+
+int	handle_key_press(int keycode, t_game *game)
+{
+	if (keycode == KEY_W)
+		game->input.move_forward = true;
+	else if (keycode == KEY_S)
+		game->input.move_backward = true;
+	else if (keycode == KEY_A)
+		game->input.strafe_left = true;
+	else if (keycode == KEY_D)
+		game->input.strafe_right = true;
+	else if (keycode == KEY_LEFT)
+		game->input.turn_left = true;
+	else if (keycode == KEY_RIGHT)
+		game->input.turn_right = true;
+	else if (keycode == KEY_ESC)
+		game->input.quit = true;
+	return (0);
+}
+
+int	handle_key_release(int keycode, t_game *game)
+{
+	if (keycode == KEY_W)
+		game->input.move_forward = false;
+	else if (keycode == KEY_S)
+		game->input.move_backward = false;
+	else if (keycode == KEY_A)
+		game->input.strafe_left = false;
+	else if (keycode == KEY_D)
+		game->input.strafe_right = false;
+	else if (keycode == KEY_LEFT)
+		game->input.turn_left = false;
+	else if (keycode == KEY_RIGHT)
+		game->input.turn_right = false;
+	return (0);
+}
+
+int	handle_close(t_game *game)
+{
+	game->running = false;
+	return (0);
+}
+
+void	register_hooks(t_game *game)
+{
+	mlx_hook(game->mlx.win, 2, 1L << 0, handle_key_press, game);	// KeyPress
+	mlx_hook(game->mlx.win, 3, 1L << 1, handle_key_release, game);	// KeyRelease
+	mlx_hook(game->mlx.win, 17, 0, handle_close, game);			// DestroyNotify
+}

--- a/src/handle_input.c
+++ b/src/handle_input.c
@@ -55,9 +55,10 @@ int	handle_close(t_game *game)
 	return (0);
 }
 
+
 void	register_hooks(t_game *game)
 {
-	mlx_hook(game->mlx.win, 2, 1L << 0, handle_key_press, game);	// KeyPress
-	mlx_hook(game->mlx.win, 3, 1L << 1, handle_key_release, game);	// KeyRelease
-	mlx_hook(game->mlx.win, 17, 0, handle_close, game);			// DestroyNotify
+	mlx_hook(game->mlx.win, EVENT_KEY_PRESS, MASK_KEY_PRESS, handle_key_press, game);	
+	mlx_hook(game->mlx.win, EVENT_KEY_RELEASE, MASK_KEY_RELEASE, handle_key_release, game);	
+	mlx_hook(game->mlx.win, EVENT_DESTROY, 0, handle_close, game);
 }

--- a/src/handle_input.c
+++ b/src/handle_input.c
@@ -2,6 +2,12 @@
 #include "game_config.h"
 #include "game_init.h"
 
+// 何する関数か:
+// - `t_input` の全フィールドを `false` で初期化する。
+// 参照でいじった値:
+// - `input` の全押下フラグを `false` に設定する。
+// 戻り値の意味:
+// - なし。
 void	init_input(t_input *input)
 {
 	input->move_forward = false;
@@ -13,6 +19,13 @@ void	init_input(t_input *input)
 	input->quit = false;
 }
 
+// 何する関数か:
+// - キー押下イベントを受け取り、対応する入力フラグを `true` にする。
+// 参照でいじった値:
+// - `game->input` の各フラグを `true` に設定する。
+//   + `KEY_ESC` は `quit` を立てる一方通行フラグ。解放イベントでは落とさない。
+// 戻り値の意味:
+// - 0 (mlx のフック規約に従う)。
 int	handle_key_press(int keycode, t_game *game)
 {
 	if (keycode == KEY_W)
@@ -32,6 +45,13 @@ int	handle_key_press(int keycode, t_game *game)
 	return (0);
 }
 
+// 何する関数か:
+// - キー解放イベントを受け取り、対応する入力フラグを `false` にする。
+// 参照でいじった値:
+// - `game->input` の各移動・回転フラグを `false` に設定する。
+//   + `quit` は一方通行なので解放時に落とさない。
+// 戻り値の意味:
+// - 0 (mlx のフック規約に従う)。
 int	handle_key_release(int keycode, t_game *game)
 {
 	if (keycode == KEY_W)
@@ -49,16 +69,29 @@ int	handle_key_release(int keycode, t_game *game)
 	return (0);
 }
 
+// 何する関数か:
+// - ウィンドウの閉じるボタン押下イベントを受け取り、ゲームループを終了させる。
+// 参照でいじった値:
+// - `game->running` を `false` に設定する。
+// 戻り値の意味:
+// - 0 (mlx のフック規約に従う)。
 int	handle_close(t_game *game)
 {
 	game->running = false;
 	return (0);
 }
 
-
+// 何する関数か:
+// - mlx のイベントフックを一括登録する。
+// 参照でいじった値:
+// - なし (mlx 内部にコールバックを登録するだけ)。
+// 戻り値の意味:
+// - なし。
 void	register_hooks(t_game *game)
 {
-	mlx_hook(game->mlx.win, EVENT_KEY_PRESS, MASK_KEY_PRESS, handle_key_press, game);	
-	mlx_hook(game->mlx.win, EVENT_KEY_RELEASE, MASK_KEY_RELEASE, handle_key_release, game);	
+	mlx_hook(game->mlx.win, EVENT_KEY_PRESS, MASK_KEY_PRESS,
+		handle_key_press, game);
+	mlx_hook(game->mlx.win, EVENT_KEY_RELEASE, MASK_KEY_RELEASE,
+		handle_key_release, game);
 	mlx_hook(game->mlx.win, EVENT_DESTROY, 0, handle_close, game);
 }


### PR DESCRIPTION


## 変更内容

**入力処理の追加 (`src/handle_input.c`)**
- `init_input()` を追加し,`t_input` の全押下フラグを `false` で初期化するようにしたよ.
- `handle_key_press()` / `handle_key_release()` を追加し,WASD + 左右矢印キーの押下状態をフレーム間で保持するようにしたよ.
  - `KEY_ESC` は `quit` フラグを立てる一方通行の処理にした.解放イベントでは落とさない.
- `handle_close()` を追加し,ウィンドウの閉じるボタンで `game->running` を `false` にするようにした.
- `register_hooks()` を追加し,mlx のイベントフック登録を一箇所にまとめたよ.

**定数の集約 (`include/game_config.h`)**
- `PLAYER_MOVE_SPEED`,`PLAYER_ROT_SPEED`,`FOV_HALF_TAN` を `init_player.c` のローカル定義から `game_config.h` へ移したよ.
- `EVENT_KEY_PRESS`,`EVENT_KEY_RELEASE`,`EVENT_DESTROY`,`MASK_KEY_PRESS`,`MASK_KEY_RELEASE` を `game_config.h` に追加し,定数化したよ.
- 重複していた `#endif` を削除してガードを整理したよ.

**宣言の追加 (`include/game_init.h`)**
- `init_input()`,`handle_key_press()`,`handle_key_release()`,`handle_close()`,`register_hooks()` の宣言を追加したよ.

**sandbox の動作確認用ループ追加 (`sandbox/render/render_sandbox_main.c`)**
- `sandbox_loop_hook()` を追加し,入力フラグの状態を `printf` で確認できるようにした.
- `init_input()` / `register_hooks()` / `mlx_loop_hook()` / `mlx_loop()` を呼ぶ形に変更し,実際にウィンドウを出してキー入力を受け付けられるようにした.
- 解放処理を `sandbox_loop_hook()` 内に移し,`quit` または `running == false` になったタイミングで解放して終了するようにした.

## 動作確認

```
make -C sandbox/render
# ウィンドウが開いてWASD/左右矢印で入力ログが出ることを確認
# sandbox内で実行してフレーム間での押下状態を保持していることを確認
# ESCまたはウィンドウを閉じると終了することを確認
```
