### PR TITLE
read_all_line()に変更

### DIFF
--- a/src/parse/open_cub_file/read_all_lines.c
+++ b/src/parse/open_cub_file/read_all_lines.c
@@ -6,13 +6,13 @@
 /*   By: okunoitsuki <okunoitsuki@student.42.fr>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/03/14 14:26:54 by iokuno            #+#    #+#             */
-/*   Updated: 2026/03/22 21:42:58 by okunoitsuki      ###   ########.fr       */
+/*   Updated: 2026/03/22 21:50:03 by okunoitsuki      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "libft.h"
 #include <stdlib.h>
 #include <unistd.h>
-#include "get_next_line.h"
 
 // 概要 : 配列を拡張する（realloc的な動き）
 // 返り値 : NULL終端でsizeの大きさに拡張された配列
@@ -53,7 +53,7 @@ static void free_lines(char **lines)
 
 // 概要 : FDから全行をメモリに書き込みNULL終端のchar**で返す
 // 返り値 : ファイルを1行ずつ保有する二次元配列（ダブルポインタ）
-// エラー処理 :
+// エラー処理 : 配列の拡張が失敗したら途中まで確保した配列を全て開放してNULLを返す。
 // 開放義務 : アリ
 
 char **read_all_lines(int fd)

--- a/src/parse/open_cub_file/read_all_lines.c
+++ b/src/parse/open_cub_file/read_all_lines.c
@@ -1,0 +1,87 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   read_all_lines.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: okunoitsuki <okunoitsuki@student.42.fr>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/03/14 14:26:54 by iokuno            #+#    #+#             */
+/*   Updated: 2026/03/22 21:42:58 by okunoitsuki      ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include "get_next_line.h"
+
+// 概要 : 配列を拡張する（realloc的な動き）
+// 返り値 : NULL終端でsizeの大きさに拡張された配列
+static char **expand_lines(char **lines, int size)
+{
+	char **new_lines;
+	int i;
+
+	new_lines = malloc(sizeof(char *) * (size + 1));
+	if (!new_lines)
+		return (NULL);
+	i = 0;
+	while (i < size)
+	{
+		new_lines[i] = lines[i];
+		i++;
+	}
+	new_lines[size] = NULL;
+	free(lines);
+	return (new_lines);
+}
+
+// 概要 : linesを全解放
+static void free_lines(char **lines)
+{
+	int i;
+
+	if (!lines)
+		return;
+	i = 0;
+	while (lines[i])
+	{
+		free(lines[i]);
+		i++;
+	}
+	free(lines);
+}
+
+// 概要 : FDから全行をメモリに書き込みNULL終端のchar**で返す
+// 返り値 : ファイルを1行ずつ保有する二次元配列（ダブルポインタ）
+// エラー処理 :
+// 開放義務 : アリ
+
+char **read_all_lines(int fd)
+{
+	char *line;
+	char **lines;
+	int count;
+
+	lines = NULL;
+	count = 0;
+	while (1)
+	{
+		// TODO : issue 5
+		line = get_next_line(fd);
+		if (!line)
+			break;
+		lines = expand_lines(lines, count);
+		if (!lines)
+		{
+			free(line);
+			free_lines(lines);
+			return (NULL);
+		}
+		lines[count] = line;
+		count++;
+	}
+	lines = expand_lines(lines, count);
+	if (!lines)
+		return (NULL);
+	return (lines);
+}


### PR DESCRIPTION
# 概要
動的に確保するように変更

## 詳細
前の実装だと`char **`に代入してたけど、二次元配列は大きさがファイルの行数によって変わるのでヒープに確保する必要がある。
#5 は後でGNL書き直します